### PR TITLE
Revive Scala 2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 3.1.1]
+        scala: [2.13.8, 2.12.15, 3.1.1]
         java: [temurin@8, temurin@11, temurin@17]
         project: [rootJVM]
         exclude:
+          - scala: 2.12.15
+            java: temurin@11
+          - scala: 2.12.15
+            java: temurin@17
           - scala: 3.1.1
             java: temurin@11
           - scala: 3.1.1
@@ -243,6 +247,16 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13.8-rootJVM
 
       - name: Inflate target directories (2.13.8, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (2.12.15, rootJVM)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.15-rootJVM
+
+      - name: Inflate target directories (2.12.15, rootJVM)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ ThisBuild / developers := List(
 ThisBuild / tlSitePublishBranch := Some("main")
 
 val Scala213 = "2.13.8"
-ThisBuild / crossScalaVersions := Seq(Scala213, "3.1.1")
+ThisBuild / crossScalaVersions := Seq(Scala213, "2.12.15", "3.1.1")
 ThisBuild / scalaVersion := Scala213 // the default Scala
 
 val asyncHttpClientVersion = "2.12.3"


### PR DESCRIPTION
We will drop it again for the 1.0-based branches