### PR TITLE
Use a queue-based reader for ServletInputStream

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -60,7 +60,7 @@ class AsyncHttp4sServlet[F[_]](
       val ctx = servletRequest.startAsync()
       ctx.setTimeout(asyncTimeoutMillis)
       // Must be done on the container thread for Tomcat's sake when using async I/O.
-      val bodyWriter = servletIo.initWriter(servletResponse)
+      val bodyWriter = servletIo.bodyWriter(servletResponse, dispatcher) _
       val result = F
         .attempt(
           toRequest(servletRequest).fold(

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -50,7 +50,7 @@ class BlockingHttp4sServlet[F[_]](
   ): Unit = {
     val result = F
       .defer {
-        val bodyWriter = servletIo.initWriter(servletResponse)
+        val bodyWriter = servletIo.bodyWriter(servletResponse, dispatcher) _
 
         val render = toRequest(servletRequest).fold(
           onParseFailure(_, servletResponse, bodyWriter),

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -161,7 +161,7 @@ abstract class Http4sServlet[F[_]](
       uri = uri,
       httpVersion = version,
       headers = toHeaders(req),
-      body = servletIo.reader(req),
+      body = servletIo.requestBody(req, dispatcher),
       attributes = attributes,
     )
 

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -42,9 +42,13 @@ sealed abstract class ServletIo[F[_]: Async] {
   protected[servlet] def reader(servletRequest: HttpServletRequest): EntityBody[F]
 
   @nowarn("cat=deprecation")
-  @nowarn("cat=unused")
-  def requestBody(servletRequest: HttpServletRequest, dispatcher: Dispatcher[F]): Stream[F, Byte] =
+  def requestBody(
+      servletRequest: HttpServletRequest,
+      dispatcher: Dispatcher[F],
+  ): Stream[F, Byte] = {
+    val _ = dispatcher // unused
     reader(servletRequest)
+  }
 
   /** May install a listener on the servlet response. */
   protected[servlet] def initWriter(servletResponse: HttpServletResponse): BodyWriter[F]

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -18,6 +18,8 @@ package org.http4s
 package servlet
 
 import cats.effect._
+import cats.effect.std.Dispatcher
+import cats.effect.std.Queue
 import cats.syntax.all._
 import fs2._
 import org.http4s.internal.bug
@@ -28,6 +30,7 @@ import javax.servlet.ReadListener
 import javax.servlet.WriteListener
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import scala.annotation.nowarn
 import scala.annotation.tailrec
 
 /** Determines the mode of I/O used for reading request bodies and writing response bodies.
@@ -35,7 +38,13 @@ import scala.annotation.tailrec
 sealed abstract class ServletIo[F[_]: Async] {
   protected[servlet] val F: Async[F] = Async[F]
 
+  @deprecated("Prefer requestBody, which has access to a Dispatcher", "0.23.12")
   protected[servlet] def reader(servletRequest: HttpServletRequest): EntityBody[F]
+
+  @nowarn("cat=deprecation")
+  @nowarn("cat=unused")
+  def requestBody(servletRequest: HttpServletRequest, dispatcher: Dispatcher[F]): Stream[F, Byte] =
+    reader(servletRequest)
 
   /** May install a listener on the servlet response. */
   protected[servlet] def initWriter(servletResponse: HttpServletResponse): BodyWriter[F]
@@ -182,6 +191,55 @@ final case class NonBlockingServletIo[F[_]: Async](chunkSize: Int) extends Servl
         readStream.unNoneTerminate.flatMap(Stream.chunk)
       }
     }
+
+  /* The queue implementation is influenced by ideas in jetty4s
+   * https://github.com/IndiscriminateCoding/jetty4s/blob/0.0.10/server/src/main/scala/jetty4s/server/HttpResourceHandler.scala
+   */
+  override def requestBody(
+      servletRequest: HttpServletRequest,
+      dispatcher: Dispatcher[F],
+  ): Stream[F, Byte] = {
+    sealed trait Read
+    final case class Bytes(chunk: Chunk[Byte]) extends Read
+    case object End extends Read
+    final case class Error(t: Throwable) extends Read
+
+    Stream.eval(F.delay(servletRequest.getInputStream)).flatMap { in =>
+      Stream.eval(Queue.synchronous[F, Read]).flatMap { q =>
+        val readBody = Stream.exec(F.delay(in.setReadListener(new ReadListener {
+          def onDataAvailable(): Unit = {
+            def go: F[Unit] =
+              F.delay(new Array[Byte](chunkSize)).flatMap { buff =>
+                F.delay(in.read(buff)).flatMap {
+                  case len if len >= 0 =>
+                    q.offer(Bytes(Chunk.array(buff, 0, len))) >>
+                      F.delay(in.isReady()).flatMap {
+                        case true => go
+                        case false => F.unit
+                      }
+                  case _ =>
+                    F.unit
+                }
+              }
+            dispatcher.unsafeRunSync(go)
+          }
+          def onAllDataRead(): Unit =
+            dispatcher.unsafeRunSync(q.offer(End))
+          def onError(t: Throwable): Unit =
+            dispatcher.unsafeRunSync(q.offer(Error(t)))
+        })))
+
+        def pullBody: Pull[F, Byte, Unit] =
+          Pull.eval(q.take).flatMap {
+            case Bytes(chunk) => Pull.output(chunk) >> pullBody
+            case End => Pull.done
+            case Error(t) => Pull.raiseError[F](t)
+          }
+
+        pullBody.stream.concurrently(readBody)
+      }
+    }
+  }
 
   override protected[servlet] def initWriter(
       servletResponse: HttpServletResponse


### PR DESCRIPTION
This is a much simpler implementation of reading a servlet request body.  I have not benchmarked it, but I feel more confident in it.  It uses Cats-Effect 3 tools that weren't available when I wrote the original.

It's inspired by @IndiscriminateCoding's excellent work on jetty4s. 