### PR TITLE
Blocking servlets require blocking Servlet I/O

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -26,13 +26,21 @@ import org.http4s.server._
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-class BlockingHttp4sServlet[F[_]](
+class BlockingHttp4sServlet[F[_]] private (
     service: HttpApp[F],
     servletIo: ServletIo[F],
     serviceErrorHandler: ServiceErrorHandler[F],
     dispatcher: Dispatcher[F],
 )(implicit F: Sync[F])
     extends Http4sServlet[F](service, servletIo, dispatcher) {
+
+  def this(
+      service: HttpApp[F],
+      servletIo: BlockingServletIo[F],
+      serviceErrorHandler: ServiceErrorHandler[F],
+      dispatcher: Dispatcher[F],
+  )(implicit F: Sync[F]) =
+    this(service, servletIo: ServletIo[F], serviceErrorHandler, dispatcher)(F)
 
   @deprecated("Binary compatibility", "0.23.12")
   private[servlet] def this(


### PR DESCRIPTION
This is a source-breaking change, but anyone who configured it otherwise was suffering at runtime.  And I think hardly anyone is using the blocking anyway.