### PR TITLE
Servlet 5 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.24" // your current series x.y
+ThisBuild / tlBaseVersion := "0.25" // your current series x.y
 
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(
@@ -21,10 +21,10 @@ ThisBuild / tlJdkRelease := Some(8)
 lazy val root = tlCrossRootProject.aggregate(servlet, examples)
 
 val asyncHttpClientVersion = "2.12.3"
-val jettyVersion = "10.0.9"
+val jettyVersion = "11.0.9"
 val http4sVersion = "0.23.12"
 val munitCatsEffectVersion = "1.0.7"
-val servletApiVersion = "4.0.1"
+val servletApiVersion = "5.0.0"
 
 lazy val servlet = project
   .in(file("servlet"))
@@ -33,7 +33,7 @@ lazy val servlet = project
     description := "Portable servlet implementation for http4s servers",
     startYear := Some(2013),
     libraryDependencies ++= Seq(
-      "javax.servlet" % "javax.servlet-api" % servletApiVersion % Provided,
+      "jakarta.servlet" % "jakarta.servlet-api" % servletApiVersion % Provided,
       "org.eclipse.jetty" % "jetty-client" % jettyVersion % Test,
       "org.eclipse.jetty" % "jetty-server" % jettyVersion % Test,
       "org.eclipse.jetty" % "jetty-servlet" % jettyVersion % Test,
@@ -54,7 +54,7 @@ lazy val examples = project
     fork := true,
     Jetty / containerLibs := List("org.eclipse.jetty" % "jetty-runner" % jettyVersion),
     libraryDependencies ++= Seq(
-      "javax.servlet" % "javax.servlet-api" % servletApiVersion % Provided
+      "jakarta.servlet" % "jakarta.servlet-api" % servletApiVersion % Provided
     ),
   )
   .dependsOn(servlet)

--- a/examples/src/main/scala/com/example/Bootstrap.scala
+++ b/examples/src/main/scala/com/example/Bootstrap.scala
@@ -22,9 +22,9 @@ import cats.effect.unsafe.implicits.global
 import org.http4s._
 import org.http4s.servlet.syntax._
 
-import javax.servlet.ServletContextEvent
-import javax.servlet.ServletContextListener
-import javax.servlet.annotation.WebListener
+import jakarta.servlet.ServletContextEvent
+import jakarta.servlet.ServletContextListener
+import jakarta.servlet.annotation.WebListener
 
 @WebListener
 /** 1. To start from sbt: `examples/Jetty/start`

--- a/examples/src/main/scala/com/example/Bootstrap.scala
+++ b/examples/src/main/scala/com/example/Bootstrap.scala
@@ -19,12 +19,11 @@ package com.example
 import cats.effect.IO
 import cats.effect.std.Dispatcher
 import cats.effect.unsafe.implicits.global
-import org.http4s._
-import org.http4s.servlet.syntax._
-
 import jakarta.servlet.ServletContextEvent
 import jakarta.servlet.ServletContextListener
 import jakarta.servlet.annotation.WebListener
+import org.http4s._
+import org.http4s.servlet.syntax._
 
 @WebListener
 /** 1. To start from sbt: `examples/Jetty/start`

--- a/servlet/src/main/scala/org/http4s/servlet/AbstractAsyncListener.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AbstractAsyncListener.scala
@@ -16,8 +16,8 @@
 
 package org.http4s.servlet
 
-import javax.servlet.AsyncEvent
-import javax.servlet.AsyncListener
+import jakarta.servlet.AsyncEvent
+import jakarta.servlet.AsyncListener
 
 protected[servlet] abstract class AbstractAsyncListener extends AsyncListener {
   override def onComplete(event: AsyncEvent): Unit = {}

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -23,9 +23,9 @@ import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import org.http4s.server._
 
-import javax.servlet._
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet._
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import scala.concurrent.duration.Duration
 
 class AsyncHttp4sServlet[F[_]](

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -21,11 +21,11 @@ import cats.effect.kernel.Async
 import cats.effect.kernel.Deferred
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
-import org.http4s.server._
-
 import jakarta.servlet._
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.http4s.server._
+
 import scala.concurrent.duration.Duration
 
 class AsyncHttp4sServlet[F[_]](

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -22,8 +22,8 @@ import cats.effect.std.Dispatcher
 import cats.syntax.all._
 import org.http4s.server._
 
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 
 class BlockingHttp4sServlet[F[_]] private (
     service: HttpApp[F],

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -20,10 +20,9 @@ package servlet
 import cats.effect.kernel.Sync
 import cats.effect.std.Dispatcher
 import cats.syntax.all._
-import org.http4s.server._
-
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.http4s.server._
 
 class BlockingHttp4sServlet[F[_]] private (
     service: HttpApp[F],

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -32,11 +32,11 @@ import org.typelevel.ci._
 import org.typelevel.vault._
 
 import java.security.cert.X509Certificate
-import javax.servlet.ServletConfig
-import javax.servlet.http.HttpServlet
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
-import javax.servlet.http.HttpSession
+import jakarta.servlet.ServletConfig
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpSession
 
 abstract class Http4sServlet[F[_]](
     service: HttpApp[F],
@@ -135,12 +135,12 @@ abstract class Http4sServlet[F[_]](
           .insert(
             ServerRequestKeys.SecureSession,
             (
-              Option(req.getAttribute("javax.servlet.request.ssl_session_id").asInstanceOf[String]),
-              Option(req.getAttribute("javax.servlet.request.cipher_suite").asInstanceOf[String]),
-              Option(req.getAttribute("javax.servlet.request.key_size").asInstanceOf[Int]),
+              Option(req.getAttribute("jakarta.servlet.request.ssl_session_id").asInstanceOf[String]),
+              Option(req.getAttribute("jakarta.servlet.request.cipher_suite").asInstanceOf[String]),
+              Option(req.getAttribute("jakarta.servlet.request.key_size").asInstanceOf[Int]),
               Option(
                 req
-                  .getAttribute("javax.servlet.request.X509Certificate")
+                  .getAttribute("jakarta.servlet.request.X509Certificate")
                   .asInstanceOf[Array[X509Certificate]]
               ),
             )

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -22,6 +22,11 @@ import cats.syntax.all._
 import com.comcast.ip4s.IpAddress
 import com.comcast.ip4s.Port
 import com.comcast.ip4s.SocketAddress
+import jakarta.servlet.ServletConfig
+import jakarta.servlet.http.HttpServlet
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpSession
 import org.http4s._
 import org.http4s.internal.CollectionCompat.CollectionConverters._
 import org.http4s.server.SecureSession
@@ -32,11 +37,6 @@ import org.typelevel.ci._
 import org.typelevel.vault._
 
 import java.security.cert.X509Certificate
-import jakarta.servlet.ServletConfig
-import jakarta.servlet.http.HttpServlet
-import jakarta.servlet.http.HttpServletRequest
-import jakarta.servlet.http.HttpServletResponse
-import jakarta.servlet.http.HttpSession
 
 abstract class Http4sServlet[F[_]](
     service: HttpApp[F],

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -135,7 +135,9 @@ abstract class Http4sServlet[F[_]](
           .insert(
             ServerRequestKeys.SecureSession,
             (
-              Option(req.getAttribute("jakarta.servlet.request.ssl_session_id").asInstanceOf[String]),
+              Option(
+                req.getAttribute("jakarta.servlet.request.ssl_session_id").asInstanceOf[String]
+              ),
               Option(req.getAttribute("jakarta.servlet.request.cipher_suite").asInstanceOf[String]),
               Option(req.getAttribute("jakarta.servlet.request.key_size").asInstanceOf[Int]),
               Option(

--- a/servlet/src/main/scala/org/http4s/servlet/ServletApiVersion.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletApiVersion.scala
@@ -16,7 +16,7 @@
 
 package org.http4s.servlet
 
-import javax.servlet.ServletContext
+import jakarta.servlet.ServletContext
 import scala.math.Ordered.orderingToOrdered
 
 final case class ServletApiVersion(major: Int, minor: Int) extends Ordered[ServletApiVersion] {

--- a/servlet/src/main/scala/org/http4s/servlet/ServletApiVersion.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletApiVersion.scala
@@ -17,6 +17,7 @@
 package org.http4s.servlet
 
 import jakarta.servlet.ServletContext
+
 import scala.math.Ordered.orderingToOrdered
 
 final case class ServletApiVersion(major: Int, minor: Int) extends Ordered[ServletApiVersion] {

--- a/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
@@ -21,9 +21,9 @@ import cats.effect._
 import org.http4s.server.ServerBuilder
 
 import java.util
-import javax.servlet.DispatcherType
-import javax.servlet.http.HttpFilter
-import javax.servlet.http.HttpServlet
+import jakarta.servlet.DispatcherType
+import jakarta.servlet.http.HttpFilter
+import jakarta.servlet.http.HttpServlet
 
 abstract class ServletContainer[F[_]] extends ServerBuilder[F] {
   type Self <: ServletContainer[F]

--- a/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletContainer.scala
@@ -18,12 +18,12 @@ package org.http4s
 package servlet
 
 import cats.effect._
-import org.http4s.server.ServerBuilder
-
-import java.util
 import jakarta.servlet.DispatcherType
 import jakarta.servlet.http.HttpFilter
 import jakarta.servlet.http.HttpServlet
+import org.http4s.server.ServerBuilder
+
+import java.util
 
 abstract class ServletContainer[F[_]] extends ServerBuilder[F] {
   type Self <: ServletContainer[F]

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -25,10 +25,10 @@ import fs2._
 import org.log4s.getLogger
 
 import java.util.Arrays
-import javax.servlet.ReadListener
-import javax.servlet.WriteListener
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
+import jakarta.servlet.ReadListener
+import jakarta.servlet.WriteListener
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 
 /** Determines the mode of I/O used for reading request bodies and writing response bodies.
   */

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -22,13 +22,13 @@ import cats.effect.std.Dispatcher
 import cats.effect.std.Queue
 import cats.syntax.all._
 import fs2._
-import org.log4s.getLogger
-
-import java.util.Arrays
 import jakarta.servlet.ReadListener
 import jakarta.servlet.WriteListener
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.log4s.getLogger
+
+import java.util.Arrays
 
 /** Determines the mode of I/O used for reading request bodies and writing response bodies.
   */

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -24,8 +24,8 @@ import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.server.defaults
 import org.http4s.syntax.all._
 
-import javax.servlet.ServletContext
-import javax.servlet.ServletRegistration
+import jakarta.servlet.ServletContext
+import jakarta.servlet.ServletRegistration
 import scala.concurrent.duration.Duration
 
 trait ServletContextSyntax {

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -20,12 +20,12 @@ package syntax
 
 import cats.effect._
 import cats.effect.std.Dispatcher
+import jakarta.servlet.ServletContext
+import jakarta.servlet.ServletRegistration
 import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.server.defaults
 import org.http4s.syntax.all._
 
-import jakarta.servlet.ServletContext
-import jakarta.servlet.ServletRegistration
 import scala.concurrent.duration.Duration
 
 trait ServletContextSyntax {

--- a/servlet/src/test/scala/org/http4s/servlet/Http4sServletRequestStub.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/Http4sServletRequestStub.scala
@@ -16,27 +16,27 @@
 
 package org.http4s.servlet
 
-import javax.servlet.ServletInputStream
-import javax.servlet.http.HttpServletRequest
+import jakarta.servlet.ServletInputStream
+import jakarta.servlet.http.HttpServletRequest
 
 final case class HttpServletRequestStub(
     inputStream: ServletInputStream
 ) extends HttpServletRequest {
   def getInputStream(): ServletInputStream = inputStream
 
-  def authenticate(x$1: javax.servlet.http.HttpServletResponse): Boolean = ???
+  def authenticate(x$1: jakarta.servlet.http.HttpServletResponse): Boolean = ???
   def changeSessionId(): String = ???
   def getAuthType(): String = ???
   def getContextPath(): String = ???
-  def getCookies(): Array[javax.servlet.http.Cookie] = ???
+  def getCookies(): Array[jakarta.servlet.http.Cookie] = ???
   def getDateHeader(x$1: String): Long = ???
   def getHeader(x$1: String): String = ???
   def getHeaderNames(): java.util.Enumeration[String] = ???
   def getHeaders(x$1: String): java.util.Enumeration[String] = ???
   def getIntHeader(x$1: String): Int = ???
   def getMethod(): String = ???
-  def getPart(x$1: String): javax.servlet.http.Part = ???
-  def getParts(): java.util.Collection[javax.servlet.http.Part] = ???
+  def getPart(x$1: String): jakarta.servlet.http.Part = ???
+  def getParts(): java.util.Collection[jakarta.servlet.http.Part] = ???
   def getPathInfo(): String = ???
   def getPathTranslated(): String = ???
   def getQueryString(): String = ???
@@ -45,8 +45,8 @@ final case class HttpServletRequestStub(
   def getRequestURL(): StringBuffer = ???
   def getRequestedSessionId(): String = ???
   def getServletPath(): String = ???
-  def getSession(): javax.servlet.http.HttpSession = ???
-  def getSession(x$1: Boolean): javax.servlet.http.HttpSession = ???
+  def getSession(): jakarta.servlet.http.HttpSession = ???
+  def getSession(x$1: Boolean): jakarta.servlet.http.HttpSession = ???
   def getUserPrincipal(): java.security.Principal = ???
   def isRequestedSessionIdFromCookie(): Boolean = ???
   def isRequestedSessionIdFromURL(): Boolean = ???
@@ -55,15 +55,15 @@ final case class HttpServletRequestStub(
   def isUserInRole(x$1: String): Boolean = ???
   def login(x$1: String, x$2: String): Unit = ???
   def logout(): Unit = ???
-  def upgrade[T <: javax.servlet.http.HttpUpgradeHandler](x$1: Class[T]): T = ???
-  def getAsyncContext(): javax.servlet.AsyncContext = ???
+  def upgrade[T <: jakarta.servlet.http.HttpUpgradeHandler](x$1: Class[T]): T = ???
+  def getAsyncContext(): jakarta.servlet.AsyncContext = ???
   def getAttribute(x$1: String): Object = ???
   def getAttributeNames(): java.util.Enumeration[String] = ???
   def getCharacterEncoding(): String = ???
   def getContentLength(): Int = ???
   def getContentLengthLong(): Long = ???
   def getContentType(): String = ???
-  def getDispatcherType(): javax.servlet.DispatcherType = ???
+  def getDispatcherType(): jakarta.servlet.DispatcherType = ???
   def getLocalAddr(): String = ???
   def getLocalName(): String = ???
   def getLocalPort(): Int = ???
@@ -79,11 +79,11 @@ final case class HttpServletRequestStub(
   def getRemoteAddr(): String = ???
   def getRemoteHost(): String = ???
   def getRemotePort(): Int = ???
-  def getRequestDispatcher(x$1: String): javax.servlet.RequestDispatcher = ???
+  def getRequestDispatcher(x$1: String): jakarta.servlet.RequestDispatcher = ???
   def getScheme(): String = ???
   def getServerName(): String = ???
   def getServerPort(): Int = ???
-  def getServletContext(): javax.servlet.ServletContext = ???
+  def getServletContext(): jakarta.servlet.ServletContext = ???
   def isAsyncStarted(): Boolean = ???
   def isAsyncSupported(): Boolean = ???
   def isSecure(): Boolean = ???
@@ -91,8 +91,8 @@ final case class HttpServletRequestStub(
   def setAttribute(x$1: String, x$2: Object): Unit = ???
   def setCharacterEncoding(x$1: String): Unit = ???
   def startAsync(
-      x$1: javax.servlet.ServletRequest,
-      x$2: javax.servlet.ServletResponse,
-  ): javax.servlet.AsyncContext = ???
-  def startAsync(): javax.servlet.AsyncContext = ???
+      x$1: jakarta.servlet.ServletRequest,
+      x$2: jakarta.servlet.ServletResponse,
+  ): jakarta.servlet.AsyncContext = ???
+  def startAsync(): jakarta.servlet.AsyncContext = ???
 }

--- a/servlet/src/test/scala/org/http4s/servlet/TestEclipseServer.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/TestEclipseServer.scala
@@ -18,14 +18,13 @@ package org.http4s.servlet
 
 import cats.effect.IO
 import cats.effect.Resource
+import jakarta.servlet.Servlet
 import org.eclipse.jetty.server.HttpConfiguration
 import org.eclipse.jetty.server.HttpConnectionFactory
 import org.eclipse.jetty.server.ServerConnector
 import org.eclipse.jetty.server.{Server => EclipseServer}
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
-
-import jakarta.servlet.Servlet
 
 object TestEclipseServer {
 

--- a/servlet/src/test/scala/org/http4s/servlet/TestEclipseServer.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/TestEclipseServer.scala
@@ -25,7 +25,7 @@ import org.eclipse.jetty.server.{Server => EclipseServer}
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
 
-import javax.servlet.Servlet
+import jakarta.servlet.Servlet
 
 object TestEclipseServer {
 


### PR DESCRIPTION
This is identical to Servlet 4, and should remain so, except for a rename of the base package and a different dependency.  If maintaining this branch becomes a bother, we could put it on autopilot from 0.24 with a workflow that runs a sed script.  Things don't really change that fast, though.