### PR TITLE
Restore Scala 2.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.8, 3.1.2]
+        scala: [2.12.16, 2.13.8, 3.1.2]
         java: [temurin@8, temurin@11, temurin@17]
         project: [rootJVM]
         exclude:
+          - scala: 2.12.16
+            java: temurin@11
+          - scala: 2.12.16
+            java: temurin@17
           - scala: 3.1.2
             java: temurin@11
           - scala: 3.1.2
@@ -220,6 +224,16 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+
+      - name: Download target directories (2.12.16, rootJVM)
+        uses: actions/download-artifact@v2
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.12.16-rootJVM
+
+      - name: Inflate target directories (2.12.16, rootJVM)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
 
       - name: Download target directories (2.13.8, rootJVM)
         uses: actions/download-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ ThisBuild / developers := List(
 ThisBuild / tlSitePublishBranch := Some("main")
 
 val Scala213 = "2.13.8"
-ThisBuild / crossScalaVersions := Seq(Scala213, "3.1.2")
+ThisBuild / crossScalaVersions := Seq("2.12.16", Scala213, "3.1.2")
 ThisBuild / scalaVersion := Scala213 // the default Scala
 
 lazy val root = tlCrossRootProject.aggregate(servlet, examples)

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,13 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
 ThisBuild / tlBaseVersion := "0.23" // your current series x.y
 ThisBuild / tlMimaPreviousVersions ++= (0 to 11).map(y => s"0.23.$y").toSet
+ThisBuild / tlMimaPreviousVersions := {
+  scalaBinaryVersion.value match {
+    case "2.12" =>
+      (ThisBuild / tlMimaPreviousVersions).value - "0.23.12" // we missed this one... oops
+    case _ => (ThisBuild / tlMimaPreviousVersions).value
+  }
+}
 
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -257,7 +257,7 @@ final case class NonBlockingServletIo[F[_]: Async](chunkSize: Int) extends Servl
 
           def unsafeRunAndForget[A](fa: F[A]): Unit =
             dispatcher.unsafeRunAndForget(
-              fa.onError(t => F.delay(logger.error(t)("Error in servlet read listener")))
+              fa.onError { case t => F.delay(logger.error(t)("Error in servlet read listener")) }
             )
         })))
 
@@ -422,7 +422,7 @@ final case class NonBlockingServletIo[F[_]: Async](chunkSize: Int) extends Servl
 
             def unsafeRunAndForget[A](fa: F[A]): Unit =
               dispatcher.unsafeRunAndForget(
-                fa.onError(t => F.delay(logger.error(t)("Error in servlet write listener")))
+                fa.onError { case t => F.delay(logger.error(t)("Error in servlet write listener")) }
               )
           }))
 


### PR DESCRIPTION
Oops, this shouldn't be dropped until main.  If this ate you, we can backpublish 0.23.12, but nobody noticed.