### PR TITLE
Pin only Servlet 5

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,9 +1,6 @@
 updates.pin = [
-  # Servlet 4 debuts in series/0.24
-  { groupId = "javax.servlet", version = "3." },
-  # Jetty > 9 is a breaking change
-  { groupId = "org.eclipse.jetty", version = "9." },
-  { groupId = "org.eclipse.jetty.http2", version = "9." }
+  # Servlet 6 will happen on another release series
+  { groupId = "javax.servlet", version = "5." }
 ]
 
 updates.ignore = [


### PR DESCRIPTION
We'll roll with the latest Jetty, and we should take any Servlet 5 updates.  Servlet 6 is deferred to another branch, currently `servlet-6`.