### PR TITLE
Add a builder for AsyncHttp4sServlet

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -20,7 +20,6 @@ package syntax
 
 import cats.effect._
 import cats.effect.std.Dispatcher
-import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.server.defaults
 import org.http4s.syntax.all._
 
@@ -73,13 +72,12 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
       dispatcher: Dispatcher[F],
       asyncTimeout: Duration = defaults.ResponseTimeout,
   ): ServletRegistration.Dynamic = {
-    val servlet = new AsyncHttp4sServlet(
-      service = service,
-      asyncTimeout = asyncTimeout,
-      servletIo = NonBlockingServletIo(DefaultChunkSize),
-      serviceErrorHandler = DefaultServiceErrorHandler[F],
-      dispatcher,
-    )
+    val servlet = AsyncHttp4sServlet
+      .builder[F]
+      .withHttpApp(service)
+      .withAsyncTimeout(asyncTimeout)
+      .withDispatcher(dispatcher)
+      .build
     val reg = self.addServlet(name, servlet)
     reg.setLoadOnStartup(1)
     reg.setAsyncSupported(true)

--- a/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
@@ -31,7 +31,6 @@ import org.eclipse.jetty.client.api.{Response => JResponse}
 import org.eclipse.jetty.client.util.BytesContentProvider
 import org.eclipse.jetty.client.util.DeferredContentProvider
 import org.http4s.dsl.io._
-import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.syntax.all._
 
 import java.nio.ByteBuffer
@@ -255,10 +254,11 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
     clientR.use(get(_, server, "shifted")).assertEquals("shifted")
   }
 
-  private def servlet(dispatcher: Dispatcher[IO]) = new AsyncHttp4sServlet[IO](
-    service = service,
-    servletIo = NonBlockingServletIo[IO](DefaultChunkSize),
-    serviceErrorHandler = DefaultServiceErrorHandler[IO],
-    dispatcher = dispatcher,
-  )
+  private def servlet(dispatcher: Dispatcher[IO]) =
+    AsyncHttp4sServlet
+      .builder[IO]
+      .withHttpApp(service)
+      .withChunkSize(DefaultChunkSize)
+      .withDispatcher(dispatcher)
+      .build
 }

--- a/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
@@ -22,7 +22,6 @@ import cats.effect.std.Dispatcher
 import munit.CatsEffectSuite
 import org.http4s.HttpRoutes
 import org.http4s.dsl.io._
-import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.server.Router
 
 import java.net.URL
@@ -137,11 +136,10 @@ class RouterInServletSuite extends CatsEffectSuite {
   ): Resource[IO, Int] = TestEclipseServer(servlet(routes, dispatcher), contextPath, servletPath)
 
   private def servlet(routes: HttpRoutes[IO], dispatcher: Dispatcher[IO]) =
-    new AsyncHttp4sServlet[IO](
-      service = routes.orNotFound,
-      servletIo = org.http4s.servlet.BlockingServletIo(4096),
-      serviceErrorHandler = DefaultServiceErrorHandler,
-      dispatcher = dispatcher,
-    )
+    AsyncHttp4sServlet
+      .builder[IO]
+      .withHttpApp(routes.orNotFound)
+      .withDispatcher(dispatcher)
+      .build
 
 }


### PR DESCRIPTION
Experimental variant of the builder pattern.  Enforces that required parameters are specified via a phantom type, rather than all as constructor parameters.  The client code is pretty, but the error message is not.

Opens the door to an alternate terminator on the builder that returns a `Resource` if no `Dispatcher` is provided.