### PR TITLE
Add a builder for AsyncHttp4sServlet

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -28,14 +28,14 @@ import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 import scala.concurrent.duration.Duration
 
-class AsyncHttp4sServlet[F[_]](
-    service: HttpApp[F],
-    asyncTimeout: Duration = Duration.Inf,
+class AsyncHttp4sServlet[F[_]] private[servlet] (
+    httpApp: HttpApp[F],
+    asyncTimeout: Duration,
     servletIo: ServletIo[F],
     serviceErrorHandler: ServiceErrorHandler[F],
     dispatcher: Dispatcher[F],
 )(implicit F: Async[F])
-    extends Http4sServlet[F](service, servletIo, dispatcher) {
+    extends Http4sServlet[F](httpApp, servletIo, dispatcher) {
   private val asyncTimeoutMillis =
     if (asyncTimeout.isFinite) asyncTimeout.toMillis else -1 // -1 == Inf
 
@@ -131,16 +131,59 @@ class AsyncHttp4sServlet[F[_]](
 }
 
 object AsyncHttp4sServlet {
+
+  class Builder[F[_]] private[AsyncHttp4sServlet] (
+      httpApp: HttpApp[F],
+      dispatcher: Dispatcher[F],
+      asyncTimeout: Option[Duration],
+      chunkSize: Option[Int],
+  ) {
+    private def copy(
+        httpApp: HttpApp[F] = httpApp,
+        dispatcher: Dispatcher[F] = dispatcher,
+        asyncTimeout: Option[Duration] = asyncTimeout,
+        chunkSize: Option[Int] = chunkSize,
+    ): Builder[F] =
+      new Builder[F](
+        httpApp,
+        dispatcher,
+        asyncTimeout,
+        chunkSize,
+      ) {}
+
+    def build(implicit F: Async[F]): AsyncHttp4sServlet[F] =
+      new AsyncHttp4sServlet(
+        httpApp,
+        asyncTimeout.getOrElse(Duration.Inf),
+        NonBlockingServletIo(chunkSize.getOrElse(DefaultChunkSize)),
+        DefaultServiceErrorHandler,
+        dispatcher,
+      )
+
+    def withHttpApp(httpApp: HttpApp[F]): Builder[F] =
+      copy(httpApp = httpApp)
+
+    def withDispatcher(dispatcher: Dispatcher[F]): Builder[F] =
+      copy(dispatcher = dispatcher)
+
+    def withAsyncTimeout(asyncTimeout: Duration): Builder[F] =
+      copy(asyncTimeout = Some(asyncTimeout))
+
+    def withChunkSize(chunkSize: Int): Builder[F] =
+      copy(chunkSize = Some(chunkSize))
+  }
+
+  def builder[F[_]](httpApp: HttpApp[F], dispatcher: Dispatcher[F]): Builder[F] =
+    new Builder[F](httpApp, dispatcher, None, None) {}
+
+  @deprecated("Use `builder`.  `service` is renamed to `httpApp`.", "0.22.13")
   def apply[F[_]: Async](
       service: HttpApp[F],
       asyncTimeout: Duration = Duration.Inf,
       dispatcher: Dispatcher[F],
   ): AsyncHttp4sServlet[F] =
-    new AsyncHttp4sServlet[F](
-      service,
-      asyncTimeout,
-      NonBlockingServletIo[F](DefaultChunkSize),
-      DefaultServiceErrorHandler,
-      dispatcher,
-    )
+    AsyncHttp4sServlet
+      .builder[F](service, dispatcher)
+      .withAsyncTimeout(asyncTimeout)
+      .build
 }

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -26,11 +26,12 @@ import org.http4s.server._
 import javax.servlet._
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+import scala.annotation.nowarn
 import scala.concurrent.duration.Duration
 
-class AsyncHttp4sServlet[F[_]] private[servlet] (
+class AsyncHttp4sServlet[F[_]] @deprecated("Use AsyncHttp4sServlet.builder", "0.23.12") (
     httpApp: HttpApp[F],
-    asyncTimeout: Duration,
+    asyncTimeout: Duration = Duration.Inf,
     servletIo: ServletIo[F],
     serviceErrorHandler: ServiceErrorHandler[F],
     dispatcher: Dispatcher[F],
@@ -151,6 +152,7 @@ object AsyncHttp4sServlet {
         chunkSize,
       ) {}
 
+    @nowarn("cat=deprecation")
     def build(implicit F: Async[F]): AsyncHttp4sServlet[F] =
       new AsyncHttp4sServlet(
         httpApp,

--- a/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/syntax/ServletContextSyntax.scala
@@ -20,7 +20,6 @@ package syntax
 
 import cats.effect._
 import cats.effect.std.Dispatcher
-import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.server.defaults
 import org.http4s.syntax.all._
 
@@ -73,13 +72,10 @@ final class ServletContextOps private[syntax] (val self: ServletContext) extends
       dispatcher: Dispatcher[F],
       asyncTimeout: Duration = defaults.ResponseTimeout,
   ): ServletRegistration.Dynamic = {
-    val servlet = new AsyncHttp4sServlet(
-      service = service,
-      asyncTimeout = asyncTimeout,
-      servletIo = NonBlockingServletIo(DefaultChunkSize),
-      serviceErrorHandler = DefaultServiceErrorHandler[F],
-      dispatcher,
-    )
+    val servlet = AsyncHttp4sServlet
+      .builder[F](service, dispatcher)
+      .withAsyncTimeout(asyncTimeout)
+      .build
     val reg = self.addServlet(name, servlet)
     reg.setLoadOnStartup(1)
     reg.setAsyncSupported(true)

--- a/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
@@ -31,7 +31,6 @@ import org.eclipse.jetty.client.api.{Response => JResponse}
 import org.eclipse.jetty.client.util.BytesContentProvider
 import org.eclipse.jetty.client.util.DeferredContentProvider
 import org.http4s.dsl.io._
-import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.syntax.all._
 
 import java.nio.ByteBuffer
@@ -255,10 +254,9 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
     clientR.use(get(_, server, "shifted")).assertEquals("shifted")
   }
 
-  private def servlet(dispatcher: Dispatcher[IO]) = new AsyncHttp4sServlet[IO](
-    service = service,
-    servletIo = NonBlockingServletIo[IO](DefaultChunkSize),
-    serviceErrorHandler = DefaultServiceErrorHandler[IO],
-    dispatcher = dispatcher,
-  )
+  private def servlet(dispatcher: Dispatcher[IO]) =
+    AsyncHttp4sServlet
+      .builder[IO](service, dispatcher)
+      .withChunkSize(DefaultChunkSize)
+      .build
 }

--- a/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
@@ -22,7 +22,6 @@ import cats.effect.std.Dispatcher
 import munit.CatsEffectSuite
 import org.http4s.HttpRoutes
 import org.http4s.dsl.io._
-import org.http4s.server.DefaultServiceErrorHandler
 import org.http4s.server.Router
 
 import java.net.URL
@@ -137,11 +136,8 @@ class RouterInServletSuite extends CatsEffectSuite {
   ): Resource[IO, Int] = TestEclipseServer(servlet(routes, dispatcher), contextPath, servletPath)
 
   private def servlet(routes: HttpRoutes[IO], dispatcher: Dispatcher[IO]) =
-    new AsyncHttp4sServlet[IO](
-      service = routes.orNotFound,
-      servletIo = org.http4s.servlet.BlockingServletIo(4096),
-      serviceErrorHandler = DefaultServiceErrorHandler,
-      dispatcher = dispatcher,
-    )
+    AsyncHttp4sServlet
+      .builder[IO](routes.orNotFound, dispatcher)
+      .build
 
 }


### PR DESCRIPTION
A traditional builder for `AsyncHttp4sServlet`.  Positions us to add configuration in a binary-compatible fashion.
