### PR TITLE
Unpin from 0.23, which is EOL

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,13 +5,3 @@ updates.pin = [
   { groupId = "org.eclipse.jetty", version = "10." },
   { groupId = "org.eclipse.jetty.http2", version = "10." }
 ]
-
-updates.ignore = [
-  # Inherit from series/0.23
-  { groupId = "org.http4s", artifactId = "http4s-dsl" },
-  { groupId = "org.http4s", artifactId = "http4s-server" },
-  { groupId = "org.http4s", artifactId = "http4s-scalafix-internal" },
-  { groupId = "org.http4s", artifactId = "sbt-http4s-org" },
-  { groupId = "org.scala-lang", artifactId = "scala3-library" },
-  { groupId = "org.scala-sbt", artifactId = "sbt" }
-]


### PR DESCRIPTION
0.23 will be EOL on next release.  Unpin the dependencies.