### PR TITLE
Test async timeout

### DIFF
--- a/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/AsyncHttp4sServletSuite.scala
@@ -53,23 +53,27 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
         // Wait for a bit to make sure we lose the race
         (IO.sleep(50.millis) *>
           Ok("shifted")).evalOn(munitExecutionContext)
+      case GET -> Root / "never" =>
+        IO.never
     }
     .orNotFound
 
-  private val servletServer =
-    ResourceFixture[Int](Dispatcher.parallel[IO].flatMap(d => TestEclipseServer(servlet(d))))
+  private def servletServer(asyncTimeout: FiniteDuration = 10.seconds) =
+    ResourceFixture[Int](
+      Dispatcher.parallel[IO].flatMap(d => TestEclipseServer(servlet(d, asyncTimeout)))
+    )
 
   private def get(client: HttpClient, serverPort: Int, path: String): IO[String] =
     IO.blocking(
       client.GET(s"http://127.0.0.1:$serverPort/$path")
     ).map(_.getContentAsString)
 
-  servletServer.test("AsyncHttp4sServlet handle GET requests") { server =>
+  servletServer().test("AsyncHttp4sServlet handle GET requests") { server =>
     clientR.use(get(_, server, "simple")).assertEquals("simple")
   }
 
   // We should handle an empty body
-  servletServer.test("AsyncHttp4sServlet handle empty POST") { server =>
+  servletServer().test("AsyncHttp4sServlet handle empty POST") { server =>
     clientR
       .use { client =>
         IO.blocking(
@@ -82,7 +86,7 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
   }
 
   // We should handle a regular, big body
-  servletServer.test("AsyncHttp4sServlet handle multiple chunks upfront") { server =>
+  servletServer().test("AsyncHttp4sServlet handle multiple chunks upfront") { server =>
     val bytes = Stream.range(0, DefaultChunkSize * 2).map(_.toByte).to(Array)
     clientR
       .use { client =>
@@ -97,7 +101,7 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
   }
 
   // We should be able to wake up if we're initially blocked
-  servletServer.test("AsyncHttp4sServlet handle single-chunk, deferred POST") { server =>
+  servletServer().test("AsyncHttp4sServlet handle single-chunk, deferred POST") { server =>
     val bytes = Stream.range(0, DefaultChunkSize).map(_.toByte).to(Array)
     clientR
       .use { client =>
@@ -131,7 +135,7 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
   }
 
   // We should be able to wake up after being blocked
-  servletServer.test("AsyncHttp4sServlet handle two-chunk, deferred POST") { server =>
+  servletServer().test("AsyncHttp4sServlet handle two-chunk, deferred POST") { server =>
     // Show that we can read, be blocked, and read again
     val bytes = Stream.range(0, DefaultChunkSize).map(_.toByte).to(Array)
     Dispatcher
@@ -174,7 +178,7 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
   }
 
   // We shouldn't block when we receive less than a chunk at a time
-  servletServer.test("AsyncHttp4sServlet handle two itsy-bitsy deferred chunk POST") { server =>
+  servletServer().test("AsyncHttp4sServlet handle two itsy-bitsy deferred chunk POST") { server =>
     Dispatcher
       .parallel[IO]
       .use { dispatcher =>
@@ -214,52 +218,58 @@ class AsyncHttp4sServletSuite extends CatsEffectSuite {
       .assertEquals(Chunk(0.toByte, 1.toByte))
   }
 
-  servletServer.test("AsyncHttp4sServlet should not reorder lots of itsy-bitsy chunks") { server =>
-    val body = (0 until 4096).map(_.toByte).toArray
-    Dispatcher
-      .parallel[IO]
-      .use { dispatcher =>
-        clientR.use { client =>
-          for {
-            content <- IO(new DeferredContentProvider())
-            bodyFiber <- IO
-              .async_[Chunk[Byte]] { cb =>
-                var body = Chunk.empty[Byte]
-                client
-                  .POST(s"http://127.0.0.1:$server/echo")
-                  .content(content)
-                  .send(new JResponse.Listener {
-                    override def onContent(resp: JResponse, bb: ByteBuffer) =
-                      dispatcher.unsafeRunSync(for {
-                        buf <- IO(new Array[Byte](bb.remaining()))
-                        _ <- IO(bb.get(buf))
-                        _ <- IO { body = body ++ Chunk.array(buf) }
-                      } yield ())
-                    override def onFailure(resp: JResponse, t: Throwable) =
-                      cb(Left(t))
-                    override def onSuccess(resp: JResponse) =
-                      cb(Right(body))
-                  })
-              }
-              .start
-            _ <- body.toList.traverse_(b =>
-              IO(content.offer(ByteBuffer.wrap(Array[Byte](b)))) >> IO(content.flush())
-            )
-            _ <- IO(content.close())
-            body <- bodyFiber.joinWithNever
-          } yield body
+  servletServer().test("AsyncHttp4sServlet should not reorder lots of itsy-bitsy chunks") {
+    server =>
+      val body = (0 until 4096).map(_.toByte).toArray
+      Dispatcher
+        .parallel[IO]
+        .use { dispatcher =>
+          clientR.use { client =>
+            for {
+              content <- IO(new DeferredContentProvider())
+              bodyFiber <- IO
+                .async_[Chunk[Byte]] { cb =>
+                  var body = Chunk.empty[Byte]
+                  client
+                    .POST(s"http://127.0.0.1:$server/echo")
+                    .content(content)
+                    .send(new JResponse.Listener {
+                      override def onContent(resp: JResponse, bb: ByteBuffer) =
+                        dispatcher.unsafeRunSync(for {
+                          buf <- IO(new Array[Byte](bb.remaining()))
+                          _ <- IO(bb.get(buf))
+                          _ <- IO { body = body ++ Chunk.array(buf) }
+                        } yield ())
+                      override def onFailure(resp: JResponse, t: Throwable) =
+                        cb(Left(t))
+                      override def onSuccess(resp: JResponse) =
+                        cb(Right(body))
+                    })
+                }
+                .start
+              _ <- body.toList.traverse_(b =>
+                IO(content.offer(ByteBuffer.wrap(Array[Byte](b)))) >> IO(content.flush())
+              )
+              _ <- IO(content.close())
+              body <- bodyFiber.joinWithNever
+            } yield body
+          }
         }
-      }
-      .assertEquals(Chunk.array(body))
+        .assertEquals(Chunk.array(body))
   }
 
-  servletServer.test("AsyncHttp4sServlet work for shifted IO") { server =>
+  servletServer().test("AsyncHttp4sServlet work for shifted IO") { server =>
     clientR.use(get(_, server, "shifted")).assertEquals("shifted")
   }
 
-  private def servlet(dispatcher: Dispatcher[IO]) =
+  servletServer(3.seconds).test("AsyncHttp4sServlet timeout fires") { server =>
+    clientR.use(get(_, server, "never")).map(_.contains("Error 500 AsyncContext timeout"))
+  }
+
+  private def servlet(dispatcher: Dispatcher[IO], asyncTimeout: FiniteDuration) =
     AsyncHttp4sServlet
       .builder[IO](service, dispatcher)
       .withChunkSize(DefaultChunkSize)
+      .withAsyncTimeout(asyncTimeout)
       .build
 }


### PR DESCRIPTION
A similar test is failing intermittently in http4s-jetty.  Was curious whether I could expose it here.  Locally: no.