### PR TITLE
Fix deprecation versions

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServletResponse
 import scala.annotation.nowarn
 import scala.concurrent.duration.Duration
 
-class AsyncHttp4sServlet[F[_]] @deprecated("Use AsyncHttp4sServlet.builder", "0.23.17") (
+class AsyncHttp4sServlet[F[_]] @deprecated("Use AsyncHttp4sServlet.builder", "0.23.13") (
     httpApp: HttpApp[F],
     asyncTimeout: Duration = Duration.Inf,
     servletIo: ServletIo[F],

--- a/servlet/src/main/scala/org/http4s/servlet/DefaultFilter.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/DefaultFilter.scala
@@ -20,7 +20,7 @@ import javax.servlet._
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
 
-@deprecated("Not releated to http4s. Will be removed from public API", "0.23.17")
+@deprecated("Not releated to http4s. Will be removed from public API", "0.23.13")
 trait DefaultFilter extends Filter {
   override def init(filterConfig: FilterConfig): Unit = {}
 


### PR DESCRIPTION
There is no http4s-servlet-0.23.17 yet.  Those numbers are for work from before the schism.