### PR TITLE
Create a sequential dispatcher for each request and response

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -61,7 +61,7 @@ class AsyncHttp4sServlet[F[_]] @deprecated("Use AsyncHttp4sServlet.builder", "0.
       val ctx = servletRequest.startAsync()
       ctx.setTimeout(asyncTimeoutMillis)
       // Must be done on the container thread for Tomcat's sake when using async I/O.
-      val bodyWriter = servletIo.bodyWriter(servletResponse, dispatcher) _
+      val bodyWriter = servletIo.bodyWriter(servletResponse) _
       val result = F
         .attempt(
           toRequest(servletRequest).fold(

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -58,7 +58,7 @@ class BlockingHttp4sServlet[F[_]] private (
   ): Unit = {
     val result = F
       .defer {
-        val bodyWriter = servletIo.bodyWriter(servletResponse, dispatcher) _
+        val bodyWriter = servletIo.bodyWriter(servletResponse) _
 
         val render = toRequest(servletRequest).fold(
           onParseFailure(_, servletResponse, bodyWriter),

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -161,7 +161,7 @@ abstract class Http4sServlet[F[_]](
       uri = uri,
       httpVersion = version,
       headers = toHeaders(req),
-      body = servletIo.requestBody(req, dispatcher),
+      body = servletIo.requestBody(req),
       attributes = attributes,
     )
 


### PR DESCRIPTION
This tests the theory of #157 that a sequential dispatcher will help performance.

I thought request and response could share, but creating the request and response on a compute thread rather than the servlet thread results in null path infos being passed to the HTTP app in the tests.  This creates the dispatcher for the bodies, where we already have effects.
