### PR TITLE
Revert #50

### DIFF
--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -61,7 +61,7 @@ class AsyncHttp4sServlet[F[_]] @deprecated("Use AsyncHttp4sServlet.builder", "0.
       val ctx = servletRequest.startAsync()
       ctx.setTimeout(asyncTimeoutMillis)
       // Must be done on the container thread for Tomcat's sake when using async I/O.
-      val bodyWriter = servletIo.bodyWriter(servletResponse, dispatcher) _
+      val bodyWriter = servletIo.initWriter(servletResponse)
       val result = F
         .attempt(
           toRequest(servletRequest).fold(

--- a/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/BlockingHttp4sServlet.scala
@@ -58,7 +58,7 @@ class BlockingHttp4sServlet[F[_]] private (
   ): Unit = {
     val result = F
       .defer {
-        val bodyWriter = servletIo.bodyWriter(servletResponse, dispatcher) _
+        val bodyWriter = servletIo.initWriter(servletResponse)
 
         val render = toRequest(servletRequest).fold(
           onParseFailure(_, servletResponse, bodyWriter),

--- a/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/Http4sServlet.scala
@@ -161,7 +161,7 @@ abstract class Http4sServlet[F[_]](
       uri = uri,
       httpVersion = version,
       headers = toHeaders(req),
-      body = servletIo.requestBody(req, dispatcher),
+      body = servletIo.reader(req),
       attributes = attributes,
     )
 

--- a/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/ServletIo.scala
@@ -41,7 +41,7 @@ sealed abstract class ServletIo[F[_]: Async] {
   /** An alias for [[reader]].  In the future, this will be optimized with
     * the dispatcher.
     *
-    * @dispatcher currently ignored
+    * @param dispatcher currently ignored
     */
   def requestBody(
       servletRequest: HttpServletRequest,
@@ -57,7 +57,7 @@ sealed abstract class ServletIo[F[_]: Async] {
   /** An alias for [[initWriter]].  In the future, this will be
     * optimized with the dispatcher.
     *
-    * @dispatcher currently ignored
+    * @param dispatcher currently ignored
     */
   def bodyWriter(servletResponse: HttpServletResponse, dispatcher: Dispatcher[F])(
       response: Response[F]


### PR DESCRIPTION
This uses the implementations prior to #50.  Those were cleaner, but less performant (#171), and misused the parallel dispatcher (#172).

I find these implementations much harder to reason about correctness, but there is more empirical evidence of correctness.  Or at least no empirical evidence of incorrectness.