### PR TITLE
Upgrade to http4s-0.23.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val root = tlCrossRootProject.aggregate(servlet, examples)
 
 val asyncHttpClientVersion = "2.12.3"
 val jettyVersion = "9.4.50.v20221201"
-val http4sVersion = "0.23.17"
+val http4sVersion = "0.23.19"
 val munitCatsEffectVersion = "1.0.7"
 val servletApiVersion = "3.1.0"
 

--- a/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
+++ b/servlet/src/main/scala/org/http4s/servlet/AsyncHttp4sServlet.scala
@@ -76,6 +76,8 @@ class AsyncHttp4sServlet[F[_]] @deprecated("Use AsyncHttp4sServlet.builder", "0.
       dispatcher.unsafeRunAndForget(result)
     } catch errorHandler(servletRequest, servletResponse).andThen(dispatcher.unsafeRunSync _)
 
+  private[this] val noopCancelToken = Some(F.unit)
+
   private def handleRequest(
       ctx: AsyncContext,
       request: Request[F],
@@ -88,7 +90,7 @@ class AsyncHttp4sServlet[F[_]] @deprecated("Use AsyncHttp4sServlet.builder", "0.
 
       val timeout =
         F.async[Response[F]](cb =>
-          gate.complete(ctx.addListener(new AsyncTimeoutHandler(cb))).as(Option.empty[F[Unit]])
+          gate.complete(ctx.addListener(new AsyncTimeoutHandler(cb))).as(noopCancelToken)
         )
       val response =
         gate.get *>

--- a/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/BlockingHttp4sServletSuite.scala
@@ -54,7 +54,7 @@ class BlockingHttp4sServletSuite extends CatsEffectSuite {
   private def get(serverPort: Int, path: String): IO[String] =
     Resource
       .make(IO.blocking(Source.fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))))(source =>
-        IO(source.close())
+        IO.blocking(source.close())
       )
       .use { source =>
         IO.blocking(source.getLines().mkString)
@@ -74,7 +74,7 @@ class BlockingHttp4sServletSuite extends CatsEffectSuite {
       Resource
         .make(
           IO.blocking(Source.fromInputStream(conn.getInputStream, StandardCharsets.UTF_8.name))
-        )(source => IO(source.close()))
+        )(source => IO.blocking(source.close()))
         .use { source =>
           IO.blocking(source.getLines().mkString)
         }

--- a/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
+++ b/servlet/src/test/scala/org/http4s/servlet/RouterInServletSuite.scala
@@ -128,7 +128,7 @@ class RouterInServletSuite extends CatsEffectSuite {
   private def get(serverPort: Int, path: String): IO[String] =
     Resource
       .make(IO.blocking(Source.fromURL(new URL(s"http://127.0.0.1:$serverPort/$path"))))(source =>
-        IO.delay(source.close())
+        IO.blocking(source.close())
       )
       .use { source =>
         IO.blocking(source.getLines().mkString)


### PR DESCRIPTION
Backport #194, which should have targeted this branch.  This fixes the cancellation semantics of cats-effect-3.5.